### PR TITLE
Rework state sharing between task executions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v3
+
       - name: Send slack notification
         # We add this if to ensure this doesn't run on forks.
         # If you really want to run this on your own fork, configure the required secrets.
@@ -21,8 +23,7 @@ jobs:
         with:
           slack-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-
-      - uses: actions/checkout@v3
+          message-summary: Checking if ${{ github.ref_name }} needs an updated build
 
       - uses: actions/setup-node@v3
         with:
@@ -49,7 +50,7 @@ jobs:
 
       - name: Check for modified files
         id: is-modified
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo ::set-output name=modified::$(if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then echo "true"; else echo "false"; fi)
 
       - name: Push changes if there are any
         if: steps.is-modified.outputs.modified == 'true'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { setFailed } from '@actions/core'
 import { ChatPostMessageArguments, ChatUpdateArguments, WebClient } from '@slack/web-api'
+import { inspect } from 'util'
 
 import * as state from 'utils/state'
 import * as github from 'utils/github'
@@ -94,6 +95,11 @@ const cleanup = async (): Promise<void> => {
   } else {
     // TODO: Notify user we never sent a message.
   }
+}
+
+if (process.env['RUNNER_DEBUG'] === '1') {
+  console.log('Observed information')
+  console.log(inspect(state, false, null))
 }
 
 if (!state.isPost) {

--- a/src/utils/state-helper.test.ts
+++ b/src/utils/state-helper.test.ts
@@ -1,21 +1,27 @@
-import stateHelper from 'utils/state-helper'
+import stateHelper, { EXPORT_VAR_PREFIX } from 'utils/state-helper'
 import * as coreCommand from '@actions/core/lib/command'
+import { inspect } from 'util'
 
 describe('state tests', () => {
-  const name = 'testValue'
+  const name = 'TESTVALUE'
   const value = 'test'
+
+  beforeAll(() => {
+    process.env = {}
+  })
 
   it('stateHelper picks up on process.env variables', () => {
     const [unset] = stateHelper(name)
 
     // This env variable was never set, so we should expect it to be undefined
     expect(unset).toBeUndefined()
-    process.env[`STATE_${name}`] = value
+    process.env[`${EXPORT_VAR_PREFIX}${name}`] = value
 
     // While we may have set it now, stateHelper has already done its thing
     // so this variable should still be undefined
     expect(unset).toBeUndefined()
 
+    process.env[`${EXPORT_VAR_PREFIX}${name}`] = value
     const [withValue] = stateHelper(name)
     // Now that we called it after setting the env var, it should pick up on the value.
     expect(withValue).toEqual(value)
@@ -30,6 +36,7 @@ describe('state tests', () => {
   })
 
   it('returns the default when one is specified', () => {
+    delete process.env[`${EXPORT_VAR_PREFIX}${name}`]
     const defaultValue = 'this is a test'
     const [value] = stateHelper(name, { defaultValue })
 
@@ -37,7 +44,7 @@ describe('state tests', () => {
   })
 
   it('ignores "null" values', () => {
-    process.env[`STATE_${name}`] = 'null'
+    process.env[`${EXPORT_VAR_PREFIX}${name}`] = 'null'
     const [jsonValue] = stateHelper(name, {
       toValue: (val: string) => JSON.parse(val),
       fromValue: (val: Record<string, string>) => JSON.stringify(val),
@@ -48,6 +55,6 @@ describe('state tests', () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
-    delete process.env[`STATE_${name}`]
+    delete process.env[`${EXPORT_VAR_PREFIX}${name}`]
   })
 })

--- a/src/utils/state-helper.ts
+++ b/src/utils/state-helper.ts
@@ -1,6 +1,6 @@
-import { setOutput, saveState, getInput } from '@actions/core'
+import { setOutput, getInput, exportVariable } from '@actions/core'
 
-export type StateHelper<T> = [currentState: T, setState: (value: T) => void]
+export type StateHelper<T> = [currentState: T, setState: (value: T) => void, hasValue: boolean]
 export interface StateHelperOptions<T> {
   /**
    * If set, use this value as default
@@ -36,6 +36,27 @@ export interface StateHelperOptions<T> {
    * Store input to state if available
    */
   storeFromInput?: boolean
+
+  /**
+   * The function to get saved state data
+   */
+  getState?: (name: string) => string | undefined
+
+  /**
+   * The function to save state data
+   */
+  saveState?: (name: string, value: string) => void
+}
+
+export const EXPORT_VAR_PREFIX = 'SLACK_NOTIFICATION_'
+
+// We set this state in `state.ts`, but we want to have the value here to avoid exporting during post processing
+const IS_POST_PROCESSING = !!process.env[`STATE_is-post`]
+
+const _getName = (name: string): string => `${name.replace(/ /g, '_').toUpperCase()}`
+const getStateBase = (name: string): string | undefined => process.env[`${EXPORT_VAR_PREFIX}${_getName(name)}`]
+const saveStateBase = (name: string, value: string) => {
+  if (!IS_POST_PROCESSING) exportVariable(`${EXPORT_VAR_PREFIX}${_getName(name)}`, value)
 }
 
 const stateHelper = <T = string>(name: string, options?: StateHelperOptions<T>): StateHelper<T> => {
@@ -47,33 +68,42 @@ const stateHelper = <T = string>(name: string, options?: StateHelperOptions<T>):
     output = false,
     useFromInput = true,
     storeFromInput = true,
+    saveState = saveStateBase,
+    getState = getStateBase,
   } = options || {}
 
   const setState = (value: T): void => {
-    saveState(name, fromValue ? fromValue(value) : value)
+    saveState(name, (fromValue ? fromValue(value) : value) as string)
     if (output) {
       setOutput(name, fromValue ? fromValue(value) : value)
     }
   }
-
-  const value = process.env[`STATE_${name}`]
   let current: T = defaultValue as T
-  if (value) {
-    const parsed = toValue ? (toValue(value) as T) : (value as unknown as T)
-    if (parsed) {
-      current = parsed
-    }
-  } else if (useFromInput) {
+
+  let found = false
+  if (useFromInput) {
     const fromInput = getInput(name, { required })
     if (fromInput) {
       const parsed = toValue ? (toValue(fromInput) as T) : (fromInput as unknown as T)
       if (parsed) {
         current = parsed
+        found = true
         if (storeFromInput) setState(parsed)
       }
     }
   }
-  return [current, setState]
+  // If we're post-processing, we will always try to load from state to ensure the latest saved data is used
+  if (!found || IS_POST_PROCESSING) {
+    const value = getState(name)
+    if (value) {
+      const parsed = toValue ? (toValue(value) as T) : (value as unknown as T)
+      if (parsed) {
+        current = parsed
+        found = true
+      }
+    }
+  }
+  return [current, setState, found]
 }
 
 export default stateHelper

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -1,11 +1,14 @@
-import { getInput } from '@actions/core'
+import { getInput, saveState } from '@actions/core'
 import stateHelper from 'utils/state-helper'
 
+const getState = (name: string): string | undefined => process.env[`STATE_${name}`]
 export const [isPost, setIsPost] = stateHelper<boolean>('is-post', {
   toValue: (val: string) => !!val,
   fromValue: (val: boolean) => `${val}`,
   defaultValue: false,
   useFromInput: false,
+  saveState: saveState,
+  getState: getState,
 })
 // Setting this does not update `isPost`, it merely makes sure that we can detect if we're in the post action.
 setIsPost(true)


### PR DESCRIPTION
State sharing in GHA is a bit finicky, as state/inputs are paired between main and post task. The order at which the post tasks are processing are reverse of the order in which they executed, this could lead to some weird order-of-operation issues.

This changes the process to use environment variables, and to not override them during post tasks to ensure we keep the OOO.